### PR TITLE
Fix issues #12 and  #13 & Dont download transactions on wallet creation event

### DIFF
--- a/src/application/services/transactions/transactions-analytics-utils.ts
+++ b/src/application/services/transactions/transactions-analytics-utils.ts
@@ -2,12 +2,24 @@ import { TransactionType, UserTransaction } from 'src/core/entity/transaction';
 import { BigNumber } from 'bignumber.js';
 import { ImmutableDate } from 'src/core/entity/immutable-date';
 export abstract class TransactionsAnalyticUtils {
-  static filterTransactionsByDateAndByTokenSymbol(
+  static filterTransactionsByToken(
     transactions: UserTransaction[],
     tokenSymbol: string,
     poolAddress: string,
     marketName: string,
+  ) {
+    return transactions.filter(
+      (tx) =>
+        tx.tokenSymbol.equalsIgnore(tokenSymbol) &&
+        tx.poolAddress.equalsIgnore(poolAddress) &&
+        tx.marketName.equalsIgnore(marketName),
+    );
+  }
+
+  static filterTransactionsByDate(
+    transactions: UserTransaction[],
     date: ImmutableDate,
+    from?: ImmutableDate,
   ) {
     const year = date.getFullYear();
     const month = date.getMonth();
@@ -18,10 +30,7 @@ export abstract class TransactionsAnalyticUtils {
       return (
         txDate.getFullYear() === year &&
         txDate.getMonth() === month &&
-        txDate.getDate() === dayOfMonth &&
-        tx.tokenSymbol.equalsIgnore(tokenSymbol) &&
-        tx.poolAddress.equalsIgnore(poolAddress) &&
-        tx.marketName.equalsIgnore(marketName)
+        txDate.getDate() === dayOfMonth
       );
     });
   }

--- a/src/application/services/transactions/transactions-analytics-utils.ts
+++ b/src/application/services/transactions/transactions-analytics-utils.ts
@@ -30,7 +30,9 @@ export abstract class TransactionsAnalyticUtils {
       return (
         txDate.getFullYear() === year &&
         txDate.getMonth() === month &&
-        txDate.getDate() === dayOfMonth
+        txDate.getDate() === dayOfMonth &&
+        // is after from
+        (!from || from.getTime() < txDate.getTime())
       );
     });
   }

--- a/src/application/use-cases/wallet/facade/wallet-update-info-facade.ts
+++ b/src/application/use-cases/wallet/facade/wallet-update-info-facade.ts
@@ -10,6 +10,7 @@ import { Wallet } from 'src/frameworks/database/model/wallet.model';
 import { IDailyInfoFetcherFacade } from 'src/core/abstract/daily-info-facade/daily-info-facade';
 import { ProfitUtils } from 'src/application/services/profit/profit-utils';
 import { ImmutableDate } from 'src/core/entity/immutable-date';
+import { DateUtil } from 'src/shared/utils/date';
 @Injectable()
 export class WalletUpdateDailyInformationFacade {
   constructor(
@@ -22,8 +23,21 @@ export class WalletUpdateDailyInformationFacade {
     date: ImmutableDate,
   ): Promise<DailyPositionInformationForOnePosition[]> {
     const result: DailyPositionInformationForOnePosition[] = [];
+
+    const suppliedSitesWithRecentUpdatedTokens =
+      await this.databaseRepository.walletDataBaseRepository.getSitesRecentUpdatedTokensByWalletAddress(
+        wallet.address,
+        date,
+      );
+    // needed for solana rpc - filter for transactions with involved addresses
+    // if wallet withdrawed everything we will not get transactions for it
+    const poolAddresses =
+      suppliedSitesWithRecentUpdatedTokens?.flatMap((site) =>
+        site.suppliedChains?.map((chain) => chain.poolAddress),
+      ) ?? [];
+
     const dailyInformation = (
-      await this.dailyInfoFetcher.execute(wallet.address)
+      await this.dailyInfoFetcher.execute(wallet.address, poolAddresses)
     ).reduce(
       (acc, obj) => ({
         supply: [...acc.supply, ...obj.supply],
@@ -32,43 +46,41 @@ export class WalletUpdateDailyInformationFacade {
       { supply: [], userTransactions: [] } as DailyPositionsInformation,
     );
 
-    const walletWithRecentUpdatedTokenSupplies =
-      await this.databaseRepository.walletDataBaseRepository.getAllRecentUpdatedTokenSuppliedByWalletAddress(
-        wallet.address,
-        date,
-      );
-    const { supply, userTransactions } = dailyInformation;
+    let { supply, userTransactions } = dailyInformation;
 
-    if (walletWithRecentUpdatedTokenSupplies?.sitesSupplied?.length) {
-      for (const site of walletWithRecentUpdatedTokenSupplies.sitesSupplied) {
-        for (const chain of site.suppliedChains ?? []) {
-          for (const token of chain.tokens ?? []) {
-            // If token currency is missing from supply, add zero balances
-            if (
-              WalletTokenSupplied.hasSuppliedTokenBalance(token) &&
-              !supply.find(
-                (csp) =>
-                  csp.market.poolAddress.equalsIgnore(chain.poolAddress) &&
-                  csp.market.marketName.equalsIgnore(chain.marketName) &&
-                  csp.tokenSymbol.equalsIgnore(token.currency),
-              )
-            ) {
-              supply.push({
-                market: {
-                  poolAddress: chain.poolAddress,
-                  chainName: chain.chainName,
-                  marketName: chain.marketName,
-                },
-                site: site.name,
-                balance: '0',
-                balanceInUsd: '0',
-                tokenSymbol: token.currency,
-              });
-            }
+    if (onWalletCreation) {
+      userTransactions = []; // track transactions from the creation event date
+    }
+
+    for (const site of suppliedSitesWithRecentUpdatedTokens) {
+      for (const chain of site.suppliedChains ?? []) {
+        for (const token of chain.tokens ?? []) {
+          // If token currency is missing from supply, add zero balances
+          if (
+            WalletTokenSupplied.hasSuppliedTokenBalance(token) &&
+            !supply.find(
+              (csp) =>
+                csp.market.poolAddress.equalsIgnore(chain.poolAddress) &&
+                csp.market.marketName.equalsIgnore(chain.marketName) &&
+                csp.tokenSymbol.equalsIgnore(token.currency),
+            )
+          ) {
+            supply.push({
+              market: {
+                poolAddress: chain.poolAddress,
+                chainName: chain.chainName,
+                marketName: chain.marketName,
+              },
+              site: site.name,
+              balance: '0',
+              balanceInUsd: '0',
+              tokenSymbol: token.currency,
+            });
           }
         }
       }
     }
+
     for (const stb of supply) {
       const tokenSupplied = WalletTokenSupplied.getTokenSuppliedTokenFromWallet(
         wallet,
@@ -79,13 +91,24 @@ export class WalletUpdateDailyInformationFacade {
         stb.tokenSymbol,
         stb.site,
       );
+
       const currentDayTransactionsByToken =
-        TransactionsAnalyticUtils.filterTransactionsByDateAndByTokenSymbol(
-          userTransactions,
-          stb.tokenSymbol,
-          stb.market.poolAddress,
-          stb.market.marketName,
+        TransactionsAnalyticUtils.filterTransactionsByDate(
+          TransactionsAnalyticUtils.filterTransactionsByToken(
+            userTransactions,
+            stb.tokenSymbol,
+            stb.market.poolAddress,
+            stb.market.marketName,
+          ),
           date,
+          // if update was made today (by create event, only get todays trx after the creation time)
+          ...(tokenSupplied &&
+          DateUtil.checkIfLastUpdateWasAlreadyMade(
+            tokenSupplied.lastUpdate,
+            date,
+          )
+            ? [tokenSupplied?.lastUpdate]
+            : [undefined]),
         );
 
       const currentDayTransactionBalanceByToken =

--- a/src/application/use-cases/wallet/facade/wallet-update-info-facade.ts
+++ b/src/application/use-cases/wallet/facade/wallet-update-info-facade.ts
@@ -103,11 +103,8 @@ export class WalletUpdateDailyInformationFacade {
           date,
           // if update was made today (by create event, only get todays trx after the creation time)
           ...(tokenSupplied &&
-          DateUtil.checkIfLastUpdateWasAlreadyMade(
-            tokenSupplied.lastUpdate,
-            date,
-          )
-            ? [tokenSupplied?.lastUpdate]
+          tokenSupplied.historicalData?.at(0)?.createdByCreateWalletEvent
+            ? [tokenSupplied.lastUpdate]
             : [undefined]),
         );
 

--- a/src/application/use-cases/wallet/facade/wallet-update-info-facade.ts
+++ b/src/application/use-cases/wallet/facade/wallet-update-info-facade.ts
@@ -37,7 +37,11 @@ export class WalletUpdateDailyInformationFacade {
       ) ?? [];
 
     const dailyInformation = (
-      await this.dailyInfoFetcher.execute(wallet.address, poolAddresses)
+      await this.dailyInfoFetcher.execute(
+        wallet.address,
+        !onWalletCreation, // on wallet creation we dont need to get transactions
+        poolAddresses,
+      )
     ).reduce(
       (acc, obj) => ({
         supply: [...acc.supply, ...obj.supply],
@@ -47,10 +51,6 @@ export class WalletUpdateDailyInformationFacade {
     );
 
     let { supply, userTransactions } = dailyInformation;
-
-    if (onWalletCreation) {
-      userTransactions = []; // track transactions from the creation event date
-    }
 
     for (const site of suppliedSitesWithRecentUpdatedTokens) {
       for (const chain of site.suppliedChains ?? []) {

--- a/src/application/use-cases/wallet/wallet-use-case.ts
+++ b/src/application/use-cases/wallet/wallet-use-case.ts
@@ -154,7 +154,7 @@ export class WalletUseCase {
             info.supply.site,
           );
         if (tokenSupplied) {
-          const lastFileData = tokenSupplied.historicalData.at(-1);
+          const lastFileData = tokenSupplied.historicalData.at(0);
           if (lastFileData && !lastFileData.createdByCreateWalletEvent) {
             const wasToday = DateUtil.checkIfLastUpdateWasAlreadyMade(
               tokenSupplied.lastUpdate,

--- a/src/application/use-cases/wallet/wallet-use-case.ts
+++ b/src/application/use-cases/wallet/wallet-use-case.ts
@@ -9,6 +9,7 @@ import { WalletTokenSupplied } from 'src/application/services/wallet/token-suppl
 import { WalletUpdateDailyInformationFacade } from './facade/wallet-update-info-facade';
 import { DailyPositionInformationForOnePosition } from 'src/core/entity/daily-position-information';
 import { ImmutableDate } from 'src/core/entity/immutable-date';
+import { DateUtil } from 'src/shared/utils/date';
 
 @Injectable()
 export class WalletUseCase {
@@ -20,14 +21,15 @@ export class WalletUseCase {
 
   //@ToDo: remove it
   async test() {
-    // const wallet = await this.getWalletData('BAGbqJ9SerqSFeZzkFvKumhnH64G6s2PTW2VWc5MTpYG')
+    // const date = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const date = new Date();
     const test = await this.walletFacade.getDailySupplyInformation(
       {
         address: '0x56FD92cb3558D688F178AA3a9a15a1bE6631B4bf',
         sitesSupplied: [],
       },
       false,
-      new Date(),
+      date,
     );
     return test;
   }
@@ -133,24 +135,12 @@ export class WalletUseCase {
     }
   }
   private async handleWalletEntry(
-    // only in cron job we should make db updates
     wallet: Wallet,
     dailyInfo: DailyPositionInformationForOnePosition[],
     onWalletCreation: boolean,
     date: ImmutableDate,
   ) {
     try {
-      const checkIfLastUpdateWasAlreadyMade = (
-        lastUpdate: ImmutableDate,
-      ): boolean => {
-        const today = date ? date : new Date();
-        return (
-          lastUpdate.getDate() === today.getDate() &&
-          lastUpdate.getMonth() === today.getMonth() &&
-          lastUpdate.getFullYear() === today.getFullYear()
-        );
-      };
-
       // check if token on a site was already updated today
       for (const info of dailyInfo) {
         const tokenSupplied =
@@ -166,8 +156,9 @@ export class WalletUseCase {
         if (tokenSupplied) {
           const lastFileData = tokenSupplied.historicalData.at(-1);
           if (lastFileData && !lastFileData.createdByCreateWalletEvent) {
-            const wasToday = checkIfLastUpdateWasAlreadyMade(
+            const wasToday = DateUtil.checkIfLastUpdateWasAlreadyMade(
               tokenSupplied.lastUpdate,
+              date,
             );
             if (wasToday) {
               this.logger.warn(
@@ -180,7 +171,7 @@ export class WalletUseCase {
 
         info.userTransactions.forEach((tx) =>
           this.logger.log(
-            `Transaction: ${tx.txHash}, Time: ${tx.timestamp} will be handled`,
+            `Transaction: ${tx.txHash}, Time: ${tx.timestamp} will be handled for wallet ${wallet.address}`,
           ),
         );
 

--- a/src/core/abstract/daily-info-facade/daily-info-facade.ts
+++ b/src/core/abstract/daily-info-facade/daily-info-facade.ts
@@ -3,6 +3,7 @@ import { DailyPositionsInformation } from 'src/core/entity/daily-position-inform
 export abstract class IDailyInfoFetcherFacade {
   abstract execute(
     wallet: string,
+    returnTransactions: boolean,
     poolAddresses: string[],
   ): Promise<DailyPositionsInformation[]>;
 }

--- a/src/core/abstract/daily-info-facade/daily-info-facade.ts
+++ b/src/core/abstract/daily-info-facade/daily-info-facade.ts
@@ -1,5 +1,8 @@
 import { DailyPositionsInformation } from 'src/core/entity/daily-position-information';
 
 export abstract class IDailyInfoFetcherFacade {
-  abstract execute(wallet: string): Promise<DailyPositionsInformation[]>;
+  abstract execute(
+    wallet: string,
+    poolAddresses: string[],
+  ): Promise<DailyPositionsInformation[]>;
 }

--- a/src/core/abstract/database-repository.ts/wallet-repository/wallet-database-repository.ts
+++ b/src/core/abstract/database-repository.ts/wallet-repository/wallet-database-repository.ts
@@ -1,11 +1,14 @@
-import { Wallet } from 'src/frameworks/database/model/wallet.model';
+import {
+  SuppliedSite,
+  Wallet,
+} from 'src/frameworks/database/model/wallet.model';
 import { GenericDataBaseRepository } from '../generic-repository';
 import { ImmutableDate } from 'src/core/entity/immutable-date';
 
 export abstract class IWalletDatabaseRepository extends GenericDataBaseRepository<Wallet> {
   abstract findByAddress(address: string): Promise<Wallet | null>;
-  abstract getAllRecentUpdatedTokenSuppliedByWalletAddress(
+  abstract getSitesRecentUpdatedTokensByWalletAddress(
     walletAddress: string,
     date: ImmutableDate,
-  ): Promise<Wallet | null>;
+  ): Promise<SuppliedSite[]>;
 }

--- a/src/frameworks/clients/facade/daily-lending-data-fetcher-facade.ts
+++ b/src/frameworks/clients/facade/daily-lending-data-fetcher-facade.ts
@@ -13,13 +13,20 @@ export class DailyLendingDataFetcherFacade implements IDailyInfoFetcherFacade {
 
   async execute(
     wallet: string,
+    returnTransactions: boolean,
     poolAddresses: string[],
   ): Promise<DailyPositionsInformation[]> {
     return await Promise.all(
       this.lendingRestClient
         .map((lrc) => this.strategyFactory.create(lrc.SITE_NAME))
         .filter((s) => s.isExecutable(wallet))
-        .map((s) => s.getDailyPositionInformation(wallet, poolAddresses)),
+        .map((s) =>
+          s.getDailyPositionInformation(
+            wallet,
+            returnTransactions,
+            poolAddresses,
+          ),
+        ),
     );
   }
 }

--- a/src/frameworks/clients/facade/daily-lending-data-fetcher-facade.ts
+++ b/src/frameworks/clients/facade/daily-lending-data-fetcher-facade.ts
@@ -11,12 +11,15 @@ export class DailyLendingDataFetcherFacade implements IDailyInfoFetcherFacade {
   private lendingRestClient: ILendingRestClient[];
   constructor(private strategyFactory: StrategyFactory) {}
 
-  async execute(wallet: string): Promise<DailyPositionsInformation[]> {
+  async execute(
+    wallet: string,
+    poolAddresses: string[],
+  ): Promise<DailyPositionsInformation[]> {
     return await Promise.all(
       this.lendingRestClient
         .map((lrc) => this.strategyFactory.create(lrc.SITE_NAME))
         .filter((s) => s.isExecutable(wallet))
-        .map((s) => s.getDailyPositionInformation(wallet)),
+        .map((s) => s.getDailyPositionInformation(wallet, poolAddresses)),
     );
   }
 }

--- a/src/frameworks/clients/facade/strategy/get-data-strategy.ts
+++ b/src/frameworks/clients/facade/strategy/get-data-strategy.ts
@@ -12,6 +12,7 @@ export interface GetDailyInformationStrategy {
   isExecutable(wallet: string): boolean;
   getDailyPositionInformation(
     wallet: string,
+    poolAddresses?: string[],
   ): Promise<DailyPositionsInformation>;
 }
 
@@ -51,8 +52,12 @@ export class JupiterGetDailyInformationStrategy
 
   async getDailyPositionInformation(
     wallet: string,
+    poolAddresses: string[],
   ): Promise<DailyPositionsInformation> {
-    const supply = await this.client.getCurrentBalanceOfSuppliedTokens(wallet);
+    const supply = await this.client.getCurrentBalanceOfSuppliedTokens(
+      wallet,
+      poolAddresses,
+    );
     const userTransactions: UserTransaction[] = [];
     for (const s of supply) {
       const transactions = await this.connection.getTransactionsFromRpc(

--- a/src/frameworks/clients/facade/strategy/get-data-strategy.ts
+++ b/src/frameworks/clients/facade/strategy/get-data-strategy.ts
@@ -12,6 +12,7 @@ export interface GetDailyInformationStrategy {
   isExecutable(wallet: string): boolean;
   getDailyPositionInformation(
     wallet: string,
+    returnTransactions: boolean,
     poolAddresses?: string[],
   ): Promise<DailyPositionsInformation>;
 }
@@ -27,11 +28,13 @@ export class AaveGetDailyInformationStrategy
   }
   async getDailyPositionInformation(
     wallet: string,
+    returnTransactions: boolean,
   ): Promise<DailyPositionsInformation> {
     const currentSuppliedPositions =
       await this.client.getCurrentBalanceOfSuppliedTokens(wallet);
-    const userTransactions =
-      await this.client.getTransactionsOnAllChains(wallet);
+    const userTransactions = returnTransactions
+      ? await this.client.getTransactionsOnAllChains(wallet)
+      : [];
 
     return { supply: currentSuppliedPositions, userTransactions };
   }
@@ -43,7 +46,7 @@ export class JupiterGetDailyInformationStrategy
 {
   constructor(
     public readonly client: JupiterLendRestClient,
-    private connection: SolanaRpc,
+    private rpc: SolanaRpc,
   ) {}
 
   public isExecutable(walletAddress: string) {
@@ -52,6 +55,7 @@ export class JupiterGetDailyInformationStrategy
 
   async getDailyPositionInformation(
     wallet: string,
+    returnTransactions: boolean,
     poolAddresses: string[],
   ): Promise<DailyPositionsInformation> {
     const supply = await this.client.getCurrentBalanceOfSuppliedTokens(
@@ -59,19 +63,21 @@ export class JupiterGetDailyInformationStrategy
       poolAddresses,
     );
     const userTransactions: UserTransaction[] = [];
-    for (const s of supply) {
-      const transactions = await this.connection.getTransactionsFromRpc(
-        wallet,
-        s.underlyingAssetAddress,
-        {
-          poolAddress: s.market.poolAddress,
-          marketName: s.market.marketName,
-          tokenSymbol: s.tokenSymbol,
-          tokenPriceUsd: s.usdPricerPerToken,
-          siteName: s.site,
-        },
-      );
-      userTransactions.push(...transactions);
+    if (returnTransactions) {
+      for (const s of supply) {
+        const transactions = await this.rpc.getTransactionsFromRpc(
+          wallet,
+          s.underlyingAssetAddress,
+          {
+            poolAddress: s.market.poolAddress,
+            marketName: s.market.marketName,
+            tokenSymbol: s.tokenSymbol,
+            tokenPriceUsd: s.usdPricerPerToken,
+            siteName: s.site,
+          },
+        );
+        userTransactions.push(...transactions);
+      }
     }
     return { supply, userTransactions };
   }

--- a/src/frameworks/clients/lending-sites/aave-rest-client/aave-rest-client.ts
+++ b/src/frameworks/clients/lending-sites/aave-rest-client/aave-rest-client.ts
@@ -114,10 +114,4 @@ export class AaveRestClient implements ILendingRestClient {
     });
     return suppliedPositions;
   }
-
-  public async getMarkets() {
-    return this.getCurrentBalanceOfSuppliedTokens(
-      '0x56FD92cb3558D688F178AA3a9a15a1bE6631B4bf',
-    );
-  }
 }

--- a/src/frameworks/clients/lending-sites/jupiter-lend-rest-client/jupiter-lend-rest-client.ts
+++ b/src/frameworks/clients/lending-sites/jupiter-lend-rest-client/jupiter-lend-rest-client.ts
@@ -18,13 +18,18 @@ export class JupiterLendRestClient implements ILendingRestClient {
 
   async getCurrentBalanceOfSuppliedTokens(
     userAddress: string,
+    poolAddresses?: string[],
   ): Promise<SuppliedTokensBalanceWithUnderlayingAssetAdditionalData[]> {
     const data = await fetch(
       `${this.baseUrl}lend/v1/earn/positions?users=${userAddress}`,
     );
     const lendingTokensData = (await data.json()) as LendingToken[];
     return lendingTokensData
-      .filter((ltd) => ltd.underlyingAssets !== '0')
+      .filter(
+        (ltd) =>
+          ltd.underlyingAssets !== '0' ||
+          poolAddresses?.includes(ltd.token.address),
+      )
       .map((ltd) => {
         const tokenBalance = ParseUtil.divideTokenAmount(
           ltd.underlyingAssets,
@@ -47,11 +52,5 @@ export class JupiterLendRestClient implements ILendingRestClient {
           usdPricerPerToken: ltd.token.asset.price,
         };
       });
-  }
-
-  public async getMarkets() {
-    const supply = await this.getCurrentBalanceOfSuppliedTokens(
-      'BAGbqJ9SerqSFeZzkFvKumhnH64G6s2PTW2VWc5MTpYG',
-    );
   }
 }

--- a/src/frameworks/clients/lending-sites/jupiter-lend-rest-client/jupiter-lend-rest-client.ts
+++ b/src/frameworks/clients/lending-sites/jupiter-lend-rest-client/jupiter-lend-rest-client.ts
@@ -18,7 +18,7 @@ export class JupiterLendRestClient implements ILendingRestClient {
 
   async getCurrentBalanceOfSuppliedTokens(
     userAddress: string,
-    poolAddresses?: string[],
+    poolAddresses: string[],
   ): Promise<SuppliedTokensBalanceWithUnderlayingAssetAdditionalData[]> {
     const data = await fetch(
       `${this.baseUrl}lend/v1/earn/positions?users=${userAddress}`,

--- a/src/frameworks/clients/lending-sites/lending-rest-client.module.ts
+++ b/src/frameworks/clients/lending-sites/lending-rest-client.module.ts
@@ -11,10 +11,10 @@ export const LENDING_REST_CLIENTS = 'LENDING_REST_CLIENT';
     {
       provide: LENDING_REST_CLIENTS,
       useFactory: (
-        aave: AaveRestClient,
         jupiter: JupiterLendRestClient,
-      ): ILendingRestClient[] => [aave, jupiter],
-      inject: [AaveRestClient, JupiterLendRestClient],
+        aave: AaveRestClient,
+      ): ILendingRestClient[] => [jupiter, aave],
+      inject: [JupiterLendRestClient, AaveRestClient],
     },
   ],
   exports: [LENDING_REST_CLIENTS, AaveRestClient, JupiterLendRestClient],

--- a/src/frameworks/clients/lending-sites/lending-rest-client.ts
+++ b/src/frameworks/clients/lending-sites/lending-rest-client.ts
@@ -5,6 +5,6 @@ export abstract class ILendingRestClient {
   readonly SITE_NAME: SupportedSites;
   abstract getCurrentBalanceOfSuppliedTokens(
     userAddress: string,
+    poolAddress?: string[],
   ): Promise<SuppliedTokensBalance[]>;
-  abstract getMarkets(); // remove it
 }

--- a/src/frameworks/clients/rpc/solana/solana-rpc.ts
+++ b/src/frameworks/clients/rpc/solana/solana-rpc.ts
@@ -60,7 +60,7 @@ export class SolanaRpc extends Connection {
           );
           resultTrx ? result.push(resultTrx) : undefined;
         }
-        // await TimeUtil.delay(500);
+        await TimeUtil.delay(500);
       }
 
       await TimeUtil.delay(500); // throttle

--- a/src/frameworks/database-repository/wallet/wallet-repository.ts
+++ b/src/frameworks/database-repository/wallet/wallet-repository.ts
@@ -1,4 +1,7 @@
-import { Wallet } from 'src/frameworks/database/model/wallet.model';
+import {
+  SuppliedSite,
+  Wallet,
+} from 'src/frameworks/database/model/wallet.model';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Injectable } from '@nestjs/common';
@@ -36,23 +39,63 @@ export class WalletDataBaseRepository implements IWalletDatabaseRepository {
     return wallet;
   }
 
-  async getAllRecentUpdatedTokenSuppliedByWalletAddress(
+  async getSitesRecentUpdatedTokensByWalletAddress(
     walletAddress: string,
     date: ImmutableDate,
-  ): Promise<Wallet | null> {
+  ): Promise<SuppliedSite[]> {
     const dateForGettingData = date ? new Date(+date) : new Date();
     dateForGettingData.setDate(dateForGettingData.getDate() - 1);
+    const startOfDay = new Date(dateForGettingData.setHours(0, 0, 0, 0));
 
-    const wallet: Wallet | null = await this.mongoClient.findOne({
-      address: walletAddress,
-      'sitesSupplied.suppliedChains.tokens': {
-        $elemMatch: {
-          lastUpdate: {
-            $gte: new Date(dateForGettingData.setHours(0, 0, 0, 0)),
+    const result: SuppliedSite[] = await this.mongoClient.aggregate([
+      // Match wallet
+      { $match: { address: walletAddress } },
+
+      // Unwind sitesSupplied to process each site
+      { $unwind: '$sitesSupplied' },
+
+      // Unwind suppliedChains to filter tokens
+      { $unwind: '$sitesSupplied.suppliedChains' },
+
+      // Keep only tokens updated since yesterday
+      {
+        $addFields: {
+          'sitesSupplied.suppliedChains.tokens': {
+            $filter: {
+              input: '$sitesSupplied.suppliedChains.tokens',
+              as: 'token',
+              cond: { $gte: ['$$token.lastUpdate', startOfDay] },
+            },
           },
         },
       },
-    });
-    return wallet ?? null;
+
+      // Remove chains with no recent tokens
+      {
+        $match: { 'sitesSupplied.suppliedChains.tokens.0': { $exists: true } },
+      },
+
+      // Group chains back under each site
+      {
+        $group: {
+          _id: '$sitesSupplied.name', // group by site name
+          suppliedChains: { $push: '$sitesSupplied.suppliedChains' },
+        },
+      },
+
+      // Restore the site object structure
+      {
+        $project: {
+          _id: 0,
+          name: '$_id',
+          suppliedChains: 1,
+        },
+      },
+
+      // Optional: sort by site name
+      { $sort: { name: 1 } },
+    ]);
+
+    return result;
   }
 }

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -1,4 +1,17 @@
+import { ImmutableDate } from 'src/core/entity/immutable-date';
+
 export abstract class DateUtil {
+  static checkIfLastUpdateWasAlreadyMade = (
+    lastUpdate: ImmutableDate,
+    dateForCheck: ImmutableDate,
+  ): boolean => {
+    return (
+      lastUpdate.getDate() === dateForCheck.getDate() &&
+      lastUpdate.getMonth() === dateForCheck.getMonth() &&
+      lastUpdate.getFullYear() === dateForCheck.getFullYear()
+    );
+  };
+
   static convertDateToString(date: Date) {
     const day = String(date.getDate()).padStart(2, '0');
     const month = String(date.getMonth() + 1).padStart(2, '0'); // Months are 0-indexed


### PR DESCRIPTION
- #12: pass recent updated pooladdresses to solana rpc to use it in transaction involvement
- #13: track transaction from the creation wallet event. On the same day when the cron job runs we will filter transactions from create event to cron job date
- [Dont download transactions on wallet creation event](https://github.com/jmpolak/profit-tracker/pull/14/commits/c4c5d11673a640be40c2076a04895e6e15ef52e2)